### PR TITLE
Add colprefix to allow for multiple symbols to co-exist in one DataFrame

### DIFF
--- a/ta/wrapper.py
+++ b/ta/wrapper.py
@@ -18,6 +18,7 @@ def add_volume_ta(df, high, low, close, volume, fillna=False, colprefix=""):
         close (str): Name of 'close' column.
         volume (str): Name of 'volume' column.
         fillna(bool): if True, fill nan values.
+        colprefix(str): Prefix column names inserted
 
     Returns:
         pandas.core.frame.DataFrame: Dataframe with new features.
@@ -46,6 +47,7 @@ def add_volatility_ta(df, high, low, close, fillna=False, colprefix=""):
         low (str): Name of 'low' column.
         close (str): Name of 'close' column.
         fillna(bool): if True, fill nan values.
+        colprefix(str): Prefix column names inserted
 
     Returns:
         pandas.core.frame.DataFrame: Dataframe with new features.
@@ -90,6 +92,7 @@ def add_trend_ta(df, high, low, close, fillna=False, colprefix=""):
         low (str): Name of 'low' column.
         close (str): Name of 'close' column.
         fillna(bool): if True, fill nan values.
+        colprefix(str): Prefix column names inserted
 
     Returns:
         pandas.core.frame.DataFrame: Dataframe with new features.
@@ -138,6 +141,7 @@ def add_momentum_ta(df, high, low, close, volume, fillna=False, colprefix=""):
         low (str): Name of 'low' column.
         close (str): Name of 'close' column.
         fillna(bool): if True, fill nan values.
+        colprefix(str): Prefix column names inserted
 
     Returns:
         pandas.core.frame.DataFrame: Dataframe with new features.
@@ -161,6 +165,7 @@ def add_others_ta(df, close, fillna=False, colprefix=""):
         df (pandas.core.frame.DataFrame): Dataframe base.
         close (str): Name of 'close' column.
         fillna(bool): if True, fill nan values.
+        colprefix(str): Prefix column names inserted
 
     Returns:
         pandas.core.frame.DataFrame: Dataframe with new features.
@@ -182,6 +187,7 @@ def add_all_ta_features(df, open, high, low, close, volume, fillna=False, colpre
         close (str): Name of 'close' column.
         volume (str): Name of 'volume' column.
         fillna(bool): if True, fill nan values.
+        colprefix(str): Prefix column names inserted
 
     Returns:
         pandas.core.frame.DataFrame: Dataframe with new features.

--- a/ta/wrapper.py
+++ b/ta/wrapper.py
@@ -8,7 +8,7 @@ from .momentum import *
 from .others import *
 
 
-def add_volume_ta(df, high, low, close, volume, fillna=False):
+def add_volume_ta(df, high, low, close, volume, fillna=False, colprefix=""):
     """Add volume technical analysis features to dataframe.
 
     Args:
@@ -22,22 +22,22 @@ def add_volume_ta(df, high, low, close, volume, fillna=False):
     Returns:
         pandas.core.frame.DataFrame: Dataframe with new features.
     """
-    df['volume_adi'] = acc_dist_index(df[high], df[low], df[close],
+    df['{}volume_adi'.format(colprefix)] = acc_dist_index(df[high], df[low], df[close],
                                     df[volume], fillna=fillna)
-    df['volume_obv'] = on_balance_volume(df[close], df[volume], fillna=fillna)
-    df['volume_obvm'] = on_balance_volume_mean(df[close], df[volume], 10,
+    df['{}volume_obv'.format(colprefix)] = on_balance_volume(df[close], df[volume], fillna=fillna)
+    df['{}volume_obvm'.format(colprefix)] = on_balance_volume_mean(df[close], df[volume], 10,
                                     fillna=fillna)
-    df['volume_cmf'] = chaikin_money_flow(df[high], df[low], df[close],
+    df['{}volume_cmf'.format(colprefix)] = chaikin_money_flow(df[high], df[low], df[close],
                                         df[volume], fillna=fillna)
-    df['volume_fi'] = force_index(df[close], df[volume], fillna=fillna)
-    df['volume_em'] = ease_of_movement(df[high], df[low], df[close],
+    df['{}volume_fi'.format(colprefix)] = force_index(df[close], df[volume], fillna=fillna)
+    df['{}volume_em'.format(colprefix)] = ease_of_movement(df[high], df[low], df[close],
                                         df[volume], 14, fillna=fillna)
-    df['volume_vpt'] = volume_price_trend(df[close], df[volume], fillna=fillna)
-    df['volume_nvi'] = negative_volume_index(df[close], df[volume], fillna=fillna)
+    df['{}volume_vpt'.format(colprefix)] = volume_price_trend(df[close], df[volume], fillna=fillna)
+    df['{}volume_nvi'.format(colprefix)] = negative_volume_index(df[close], df[volume], fillna=fillna)
     return df
 
 
-def add_volatility_ta(df, high, low, close, fillna=False):
+def add_volatility_ta(df, high, low, close, fillna=False, colprefix=""):
     """Add volatility technical analysis features to dataframe.
 
     Args:
@@ -50,38 +50,38 @@ def add_volatility_ta(df, high, low, close, fillna=False):
     Returns:
         pandas.core.frame.DataFrame: Dataframe with new features.
     """
-    df['volatility_atr'] = average_true_range(df[high], df[low], df[close],
+    df['{}volatility_atr'.format(colprefix)] = average_true_range(df[high], df[low], df[close],
                                                 n=14, fillna=fillna)
 
-    df['volatility_bbh'] = bollinger_hband(df[close], n=20, ndev=2, fillna=fillna)
-    df['volatility_bbl'] = bollinger_lband(df[close], n=20, ndev=2, fillna=fillna)
-    df['volatility_bbm'] = bollinger_mavg(df[close], n=20, fillna=fillna)
-    df['volatility_bbhi'] = bollinger_hband_indicator(df[close], n=20, ndev=2,
+    df['{}volatility_bbh'.format(colprefix)] = bollinger_hband(df[close], n=20, ndev=2, fillna=fillna)
+    df['{}volatility_bbl'.format(colprefix)] = bollinger_lband(df[close], n=20, ndev=2, fillna=fillna)
+    df['{}volatility_bbm'.format(colprefix)] = bollinger_mavg(df[close], n=20, fillna=fillna)
+    df['{}volatility_bbhi'.format(colprefix)] = bollinger_hband_indicator(df[close], n=20, ndev=2,
                                                     fillna=fillna)
-    df['volatility_bbli'] = bollinger_lband_indicator(df[close], n=20, ndev=2,
+    df['{}volatility_bbli'.format(colprefix)] = bollinger_lband_indicator(df[close], n=20, ndev=2,
                                                     fillna=fillna)
 
-    df['volatility_kcc'] = keltner_channel_central(df[high], df[low], df[close],
+    df['{}volatility_kcc'.format(colprefix)] = keltner_channel_central(df[high], df[low], df[close],
                                                     n=10, fillna=fillna)
-    df['volatility_kch'] = keltner_channel_hband(df[high], df[low], df[close],
+    df['{}volatility_kch'.format(colprefix)] = keltner_channel_hband(df[high], df[low], df[close],
                                                     n=10, fillna=fillna)
-    df['volatility_kcl'] = keltner_channel_lband(df[high], df[low], df[close],
+    df['{}volatility_kcl'.format(colprefix)] = keltner_channel_lband(df[high], df[low], df[close],
                                                     n=10, fillna=fillna)
-    df['volatility_kchi'] = keltner_channel_hband_indicator(df[high], df[low],
+    df['{}volatility_kchi'.format(colprefix)] = keltner_channel_hband_indicator(df[high], df[low],
                                                 df[close], n=10, fillna=fillna)
-    df['volatility_kcli'] = keltner_channel_lband_indicator(df[high], df[low],
+    df['{}volatility_kcli'.format(colprefix)] = keltner_channel_lband_indicator(df[high], df[low],
                                                 df[close], n=10, fillna=fillna)
 
-    df['volatility_dch'] = donchian_channel_hband(df[close], n=20, fillna=fillna)
-    df['volatility_dcl'] = donchian_channel_lband(df[close], n=20, fillna=fillna)
-    df['volatility_dchi'] = donchian_channel_hband_indicator(df[close], n=20,
+    df['{}volatility_dch'.format(colprefix)] = donchian_channel_hband(df[close], n=20, fillna=fillna)
+    df['{}volatility_dcl'.format(colprefix)] = donchian_channel_lband(df[close], n=20, fillna=fillna)
+    df['{}volatility_dchi'.format(colprefix)] = donchian_channel_hband_indicator(df[close], n=20,
                                                             fillna=fillna)
-    df['volatility_dcli'] = donchian_channel_lband_indicator(df[close], n=20,
+    df['{}volatility_dcli'.format(colprefix)] = donchian_channel_lband_indicator(df[close], n=20,
                                                             fillna=fillna)
     return df
 
 
-def add_trend_ta(df, high, low, close, fillna=False):
+def add_trend_ta(df, high, low, close, fillna=False, colprefix=""):
     """Add trend technical analysis features to dataframe.
 
     Args:
@@ -94,42 +94,42 @@ def add_trend_ta(df, high, low, close, fillna=False):
     Returns:
         pandas.core.frame.DataFrame: Dataframe with new features.
     """
-    df['trend_macd'] = macd(df[close], n_fast=12, n_slow=26, fillna=fillna)
-    df['trend_macd_signal'] = macd_signal(df[close], n_fast=12, n_slow=26, n_sign=9,
+    df['{}trend_macd'.format(colprefix)] = macd(df[close], n_fast=12, n_slow=26, fillna=fillna)
+    df['{}trend_macd_signal'.format(colprefix)] = macd_signal(df[close], n_fast=12, n_slow=26, n_sign=9,
                                     fillna=fillna)
-    df['trend_macd_diff'] = macd_diff(df[close], n_fast=12, n_slow=26, n_sign=9,
+    df['{}trend_macd_diff'.format(colprefix)] = macd_diff(df[close], n_fast=12, n_slow=26, n_sign=9,
                                     fillna=fillna)
-    df['trend_ema_fast'] = ema_indicator(df[close], n=12, fillna=fillna)
-    df['trend_ema_slow'] = ema_indicator(df[close], n=26, fillna=fillna)
-    df['trend_adx'] = adx(df[high], df[low], df[close], n=14, fillna=fillna)
-    df['trend_adx_pos'] = adx_pos(df[high], df[low], df[close], n=14, fillna=fillna)
-    df['trend_adx_neg'] = adx_neg(df[high], df[low], df[close], n=14, fillna=fillna)
-    df['trend_vortex_ind_pos'] = vortex_indicator_pos(df[high], df[low], df[close], n=14,
+    df['{}trend_ema_fast'.format(colprefix)] = ema_indicator(df[close], n=12, fillna=fillna)
+    df['{}trend_ema_slow'.format(colprefix)] = ema_indicator(df[close], n=26, fillna=fillna)
+    df['{}trend_adx'.format(colprefix)] = adx(df[high], df[low], df[close], n=14, fillna=fillna)
+    df['{}trend_adx_pos'.format(colprefix)] = adx_pos(df[high], df[low], df[close], n=14, fillna=fillna)
+    df['{}trend_adx_neg'.format(colprefix)] = adx_neg(df[high], df[low], df[close], n=14, fillna=fillna)
+    df['{}trend_vortex_ind_pos'.format(colprefix)] = vortex_indicator_pos(df[high], df[low], df[close], n=14,
                                     fillna=fillna)
-    df['trend_vortex_ind_neg'] = vortex_indicator_neg(df[high], df[low], df[close], n=14,
+    df['{}trend_vortex_ind_neg'.format(colprefix)] = vortex_indicator_neg(df[high], df[low], df[close], n=14,
                                     fillna=fillna)
-    df['trend_vortex_diff'] = abs(df['trend_vortex_ind_pos'] - df['trend_vortex_ind_neg'])
-    df['trend_trix'] = trix(df[close], n=15, fillna=fillna)
-    df['trend_mass_index'] = mass_index(df[high], df[low], n=9, n2=25, fillna=fillna)
-    df['trend_cci'] = cci(df[high], df[low], df[close], n=20, c=0.015,
+    df['{}trend_vortex_diff'.format(colprefix)] = abs(df['{}trend_vortex_ind_pos'.format(colprefix)] - df['{}trend_vortex_ind_neg'.format(colprefix)])
+    df['{}trend_trix'.format(colprefix)] = trix(df[close], n=15, fillna=fillna)
+    df['{}trend_mass_index'.format(colprefix)] = mass_index(df[high], df[low], n=9, n2=25, fillna=fillna)
+    df['{}trend_cci'.format(colprefix)] = cci(df[high], df[low], df[close], n=20, c=0.015,
                                     fillna=fillna)
-    df['trend_dpo'] = dpo(df[close], n=20, fillna=fillna)
-    df['trend_kst'] = kst(df[close], r1=10, r2=15, r3=20, r4=30, n1=10,
+    df['{}trend_dpo'.format(colprefix)] = dpo(df[close], n=20, fillna=fillna)
+    df['{}trend_kst'.format(colprefix)] = kst(df[close], r1=10, r2=15, r3=20, r4=30, n1=10,
                             n2=10, n3=10, n4=15, fillna=fillna)
-    df['trend_kst_sig'] = kst_sig(df[close], r1=10, r2=15, r3=20, r4=30, n1=10,
+    df['{}trend_kst_sig'.format(colprefix)] = kst_sig(df[close], r1=10, r2=15, r3=20, r4=30, n1=10,
                             n2=10, n3=10, n4=15, nsig=9, fillna=fillna)
-    df['trend_kst_diff'] = df['trend_kst'] - df['trend_kst_sig']
-    df['trend_ichimoku_a'] = ichimoku_a(df[high], df[low], n1=9, n2=26, fillna=fillna)
-    df['trend_ichimoku_b'] = ichimoku_b(df[high], df[low], n2=26, n3=52, fillna=fillna)
-    df['trend_visual_ichimoku_a'] = ichimoku_a(df[high], df[low], n1=9, n2=26, visual=True, fillna=fillna)
-    df['trend_visual_ichimoku_b'] = ichimoku_b(df[high], df[low], n2=26, n3=52, visual=True, fillna=fillna)
-    df['trend_aroon_up'] = aroon_up(df[close], n=25, fillna=fillna)
-    df['trend_aroon_down'] = aroon_down(df[close], n=25, fillna=fillna)
-    df['trend_aroon_ind'] = df['trend_aroon_up'] - df['trend_aroon_down']
+    df['{}trend_kst_diff'.format(colprefix)] = df['{}trend_kst'.format(colprefix)] - df['{}trend_kst_sig'.format(colprefix)]
+    df['{}trend_ichimoku_a'.format(colprefix)] = ichimoku_a(df[high], df[low], n1=9, n2=26, fillna=fillna)
+    df['{}trend_ichimoku_b'.format(colprefix)] = ichimoku_b(df[high], df[low], n2=26, n3=52, fillna=fillna)
+    df['{}trend_visual_ichimoku_a'.format(colprefix)] = ichimoku_a(df[high], df[low], n1=9, n2=26, visual=True, fillna=fillna)
+    df['{}trend_visual_ichimoku_b'.format(colprefix)] = ichimoku_b(df[high], df[low], n2=26, n3=52, visual=True, fillna=fillna)
+    df['{}trend_aroon_up'.format(colprefix)] = aroon_up(df[close], n=25, fillna=fillna)
+    df['{}trend_aroon_down'.format(colprefix)] = aroon_down(df[close], n=25, fillna=fillna)
+    df['{}trend_aroon_ind'.format(colprefix)] = df['{}trend_aroon_up'.format(colprefix)] - df['{}trend_aroon_down'.format(colprefix)]
     return df
 
 
-def add_momentum_ta(df, high, low, close, volume, fillna=False):
+def add_momentum_ta(df, high, low, close, volume, fillna=False, colprefix=""):
     """Add trend technical analysis features to dataframe.
 
     Args:
@@ -142,19 +142,19 @@ def add_momentum_ta(df, high, low, close, volume, fillna=False):
     Returns:
         pandas.core.frame.DataFrame: Dataframe with new features.
     """
-    df['momentum_rsi'] = rsi(df[close], n=14, fillna=fillna)
-    df['momentum_mfi'] = money_flow_index(df[high], df[low], df[close],
+    df['{}momentum_rsi'.format(colprefix)] = rsi(df[close], n=14, fillna=fillna)
+    df['{}momentum_mfi'.format(colprefix)] = money_flow_index(df[high], df[low], df[close],
                                         df[volume], n=14, fillna=fillna)
-    df['momentum_tsi'] = tsi(df[close], r=25, s=13, fillna=fillna)
-    df['momentum_uo'] = uo(df[high], df[low], df[close], fillna=fillna)
-    df['momentum_stoch'] = stoch(df[high], df[low], df[close], fillna=fillna)
-    df['momentum_stoch_signal'] = stoch_signal(df[high], df[low], df[close], fillna=fillna)
-    df['momentum_wr'] = wr(df[high], df[low], df[close], fillna=fillna)
-    df['momentum_ao'] = ao(df[high], df[low], fillna=fillna)
+    df['{}momentum_tsi'.format(colprefix)] = tsi(df[close], r=25, s=13, fillna=fillna)
+    df['{}momentum_uo'.format(colprefix)] = uo(df[high], df[low], df[close], fillna=fillna)
+    df['{}momentum_stoch'.format(colprefix)] = stoch(df[high], df[low], df[close], fillna=fillna)
+    df['{}momentum_stoch_signal'.format(colprefix)] = stoch_signal(df[high], df[low], df[close], fillna=fillna)
+    df['{}momentum_wr'.format(colprefix)] = wr(df[high], df[low], df[close], fillna=fillna)
+    df['{}momentum_ao'.format(colprefix)] = ao(df[high], df[low], fillna=fillna)
     return df
 
 
-def add_others_ta(df, close, fillna=False):
+def add_others_ta(df, close, fillna=False, colprefix=""):
     """Add others analysis features to dataframe.
 
     Args:
@@ -165,13 +165,13 @@ def add_others_ta(df, close, fillna=False):
     Returns:
         pandas.core.frame.DataFrame: Dataframe with new features.
     """
-    df['others_dr'] = daily_return(df[close], fillna=fillna)
-    df['others_dlr'] = daily_log_return(df[close], fillna=fillna)
-    df['others_cr'] = cumulative_return(df[close], fillna=fillna)
+    df['{}others_dr'.format(colprefix)] = daily_return(df[close], fillna=fillna)
+    df['{}others_dlr'.format(colprefix)] = daily_log_return(df[close], fillna=fillna)
+    df['{}others_cr'.format(colprefix)] = cumulative_return(df[close], fillna=fillna)
     return df
 
 
-def add_all_ta_features(df, open, high, low, close, volume, fillna=False):
+def add_all_ta_features(df, open, high, low, close, volume, fillna=False, colprefix=""):
     """Add all technical analysis features to dataframe.
 
     Args:
@@ -186,9 +186,9 @@ def add_all_ta_features(df, open, high, low, close, volume, fillna=False):
     Returns:
         pandas.core.frame.DataFrame: Dataframe with new features.
     """
-    df = add_volume_ta(df, high, low, close, volume, fillna=fillna)
-    df = add_volatility_ta(df, high, low, close, fillna=fillna)
-    df = add_trend_ta(df, high, low, close, fillna=fillna)
-    df = add_momentum_ta(df, high, low, close, volume, fillna=fillna)
-    df = add_others_ta(df, close, fillna=fillna)
+    df = add_volume_ta(df, high, low, close, volume, fillna=fillna, colprefix=colprefix)
+    df = add_volatility_ta(df, high, low, close, fillna=fillna, colprefix=colprefix)
+    df = add_trend_ta(df, high, low, close, fillna=fillna, colprefix=colprefix)
+    df = add_momentum_ta(df, high, low, close, volume, fillna=fillna, colprefix=colprefix)
+    df = add_others_ta(df, close, fillna=fillna, colprefix=colprefix)
     return df


### PR DESCRIPTION
This allows you to prefix the new series names when calling ta_add_* functions.  The default value is "" making this backwards compatible.

It is useful when working with multiple securities at once.