### PR TITLE
Develop

### DIFF
--- a/ta/momentum.py
+++ b/ta/momentum.py
@@ -51,69 +51,6 @@ class RSIIndicator(IndicatorMixin):
         return pd.Series(rsi, name='rsi')
 
 
-class MFIIndicator(IndicatorMixin):
-    """Money Flow Index (MFI)
-
-    Uses both price and volume to measure buying and selling pressure. It is
-    positive when the typical price rises (buying pressure) and negative when
-    the typical price declines (selling pressure). A ratio of positive and
-    negative money flow is then plugged into an RSI formula to create an
-    oscillator that moves between zero and one hundred.
-
-    http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:money_flow_index_mfi
-
-    Args:
-        high(pandas.Series): dataset 'High' column.
-        low(pandas.Series): dataset 'Low' column.
-        close(pandas.Series): dataset 'Close' column.
-        volume(pandas.Series): dataset 'Volume' column.
-        n(int): n period.
-        fillna(bool): if True, fill nan values.
-    """
-
-    def __init__(self,
-                 high: pd.Series,
-                 low: pd.Series,
-                 close: pd.Series,
-                 volume: pd.Series,
-                 n: int = 14,
-                 fillna: bool = False):
-        self._high = high
-        self._low = low
-        self._close = close
-        self._volume = volume
-        self._n = n
-        self._fillna = fillna
-        self._run()
-
-    def _run(self):
-        # 1 typical price
-        tp = (self._high + self._low + self._close) / 3.0
-
-        # 2 up or down column
-        up_down = np.where(tp > tp.shift(1), 1, np.where(tp < tp.shift(1), -1, 0))
-
-        # 3 money flow
-        mf = tp * self._volume * up_down
-
-        # 4 positive and negative money flow with n periods
-        n_positive_mf = mf.rolling(self._n).apply(lambda x: np.sum(np.where(x >= 0.0, x, 0.0)), raw=True)
-        n_negative_mf = abs(mf.rolling(self._n).apply(lambda x: np.sum(np.where(x < 0.0, x, 0.0)), raw=True))
-
-        # 5 money flow index
-        mr = n_positive_mf / n_negative_mf
-        self._mr = (100 - (100 / (1 + mr)))
-
-    def money_flow_index(self) -> pd.Series:
-        """Money Flow Index (MFI)
-
-        Returns:
-            pandas.Series: New feature generated.
-        """
-        mr = self._check_fillna(self._mr, value=50)
-        return pd.Series(mr, name=f'mfi_{self._n}')
-
-
 class TSIIndicator(IndicatorMixin):
     """True strength index (TSI)
 
@@ -528,33 +465,6 @@ def rsi(close, n=14, fillna=False):
         pandas.Series: New feature generated.
     """
     return RSIIndicator(close=close, n=n, fillna=fillna).rsi()
-
-
-def money_flow_index(high, low, close, volume, n=14, fillna=False):
-    """Money Flow Index (MFI)
-
-    Uses both price and volume to measure buying and selling pressure. It is
-    positive when the typical price rises (buying pressure) and negative when
-    the typical price declines (selling pressure). A ratio of positive and
-    negative money flow is then plugged into an RSI formula to create an
-    oscillator that moves between zero and one hundred.
-
-    http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:money_flow_index_mfi
-
-    Args:
-        high(pandas.Series): dataset 'High' column.
-        low(pandas.Series): dataset 'Low' column.
-        close(pandas.Series): dataset 'Close' column.
-        volume(pandas.Series): dataset 'Volume' column.
-        n(int): n period.
-        fillna(bool): if True, fill nan values.
-
-    Returns:
-        pandas.Series: New feature generated.
-
-    """
-    indicator = MFIIndicator(high=high, low=low, close=close, volume=volume, n=n, fillna=fillna)
-    return indicator.money_flow_index()
 
 
 def tsi(close, r=25, s=13, fillna=False):

--- a/ta/tests/__init__.py
+++ b/ta/tests/__init__.py
@@ -1,7 +1,7 @@
-from ta.tests.momentum import (TestKAMAIndicator, TestMFIIndicator,
-                               TestRateOfChangeIndicator, TestRSIIndicator,
-                               TestStochasticOscillator, TestTSIIndicator,
-                               TestUltimateOscillator, TestWilliamsRIndicator)
+from ta.tests.momentum import (TestKAMAIndicator, TestRateOfChangeIndicator,
+                               TestRSIIndicator, TestStochasticOscillator,
+                               TestTSIIndicator, TestUltimateOscillator,
+                               TestWilliamsRIndicator)
 from ta.tests.trend import (TestADXIndicator, TestCCIIndicator,
                             TestMACDIndicator, TestPSARIndicator,
                             TestVortexIndicator)
@@ -9,5 +9,5 @@ from ta.tests.utils import TestGeneral
 from ta.tests.volatility import TestAverageTrueRange, TestBollingerBands
 from ta.tests.volume import (TestAccDistIndexIndicator,
                              TestEaseOfMovementIndicator,
-                             TestForceIndexIndicator,
+                             TestForceIndexIndicator, TestMFIIndicator,
                              TestOnBalanceVolumeIndicator)

--- a/ta/tests/momentum.py
+++ b/ta/tests/momentum.py
@@ -2,8 +2,8 @@ import unittest
 
 import pandas as pd
 
-from ta.momentum import (KAMAIndicator, MFIIndicator, ROCIndicator,
-                         RSIIndicator, StochasticOscillator, TSIIndicator,
+from ta.momentum import (KAMAIndicator, ROCIndicator, RSIIndicator,
+                         StochasticOscillator, TSIIndicator,
                          UltimateOscillator, WilliamsRIndicator, roc)
 from ta.tests.utils import TestIndicator
 
@@ -44,28 +44,6 @@ class TestRSIIndicator(unittest.TestCase):
     def test_rsi(self):
         target = 'RSI'
         result = self._indicator.rsi()
-        pd.testing.assert_series_equal(self._df[target].tail(), result.tail(), check_names=False)
-
-
-class TestMFIIndicator(unittest.TestCase):
-    """
-    https://school.stockcharts.com/doku.php?id=technical_indicators:money_flow_index_mfi
-    """
-
-    _filename = 'ta/tests/data/cs-mfi.csv'
-
-    def setUp(self):
-        self._df = pd.read_csv(self._filename, sep=',')
-        self._indicator = MFIIndicator(
-            high=self._df['High'], low=self._df['Low'], close=self._df['Close'], volume=self._df['Volume'], n=14,
-            fillna=False)
-
-    def tearDown(self):
-        del(self._df)
-
-    def test_mfi(self):
-        target = 'MFI'
-        result = self._indicator.money_flow_index()
         pd.testing.assert_series_equal(self._df[target].tail(), result.tail(), check_names=False)
 
 

--- a/ta/tests/utils.py
+++ b/ta/tests/utils.py
@@ -23,7 +23,7 @@ class TestGeneral(TestIndicator):
         df = ta.utils.dropna(self._df)
 
         # Add all ta features filling nans values
-        ta.add_all_ta_features(self._df, "Open", "High", "Low", "Close", "Volume_BTC", fillna=True)
+        ta.add_all_ta_features(df, "Open", "High", "Low", "Close", "Volume_BTC", fillna=True)
 
         # Add all ta features not filling nans values
-        df = ta.add_all_ta_features(self._df, "Open", "High", "Low", "Close", "Volume_BTC", fillna=False)
+        df = ta.add_all_ta_features(df, "Open", "High", "Low", "Close", "Volume_BTC", fillna=False)

--- a/ta/tests/volume.py
+++ b/ta/tests/volume.py
@@ -1,9 +1,12 @@
+import unittest
+
 import pandas as pd
 
 from ta.tests.utils import TestIndicator
 from ta.volume import (AccDistIndexIndicator, EaseOfMovementIndicator,
-                       ForceIndexIndicator, OnBalanceVolumeIndicator,
-                       acc_dist_index, ease_of_movement, force_index,
+                       ForceIndexIndicator, MFIIndicator,
+                       OnBalanceVolumeIndicator, acc_dist_index,
+                       ease_of_movement, force_index, money_flow_index,
                        on_balance_volume, sma_ease_of_movement)
 
 
@@ -98,4 +101,33 @@ class TestAccDistIndexIndicator(TestIndicator):
         result = AccDistIndexIndicator(
             high=self._df['High'], low=self._df['Low'], close=self._df['Close'], volume=self._df['Volume'],
             fillna=False).acc_dist_index()
+        pd.testing.assert_series_equal(self._df[target].tail(), result.tail(), check_names=False)
+
+
+class TestMFIIndicator(unittest.TestCase):
+    """
+    https://school.stockcharts.com/doku.php?id=technical_indicators:money_flow_index_mfi
+    """
+
+    _filename = 'ta/tests/data/cs-mfi.csv'
+
+    def setUp(self):
+        self._df = pd.read_csv(self._filename, sep=',')
+        self._indicator = MFIIndicator(
+            high=self._df['High'], low=self._df['Low'], close=self._df['Close'], volume=self._df['Volume'], n=14,
+            fillna=False)
+
+    def tearDown(self):
+        del(self._df)
+
+    def test_mfi(self):
+        target = 'MFI'
+        result = self._indicator.money_flow_index()
+        pd.testing.assert_series_equal(self._df[target].tail(), result.tail(), check_names=False)
+
+    def test_mfi2(self):
+        target = 'MFI'
+        result = money_flow_index(
+            high=self._df['High'], low=self._df['Low'], close=self._df['Close'], volume=self._df['Volume'], n=14,
+            fillna=False)
         pd.testing.assert_series_equal(self._df[target].tail(), result.tail(), check_names=False)

--- a/ta/trend.py
+++ b/ta/trend.py
@@ -496,7 +496,7 @@ class ADXIndicator(IndicatorMixin):
         self._run()
 
     def _run(self):
-        assert self._n is not 0, "N may not be 0 and is %r" % n
+        assert self._n != 0, "N may not be 0 and is %r" % n
 
         cs = self._close.shift(1)
         pdm = get_min_max(self._high, cs, 'max')

--- a/ta/utils.py
+++ b/ta/utils.py
@@ -30,6 +30,7 @@ class IndicatorMixin():
 def dropna(df):
     """Drop rows with "Nans" values
     """
+    df = df.copy()
     number_cols = df.select_dtypes('number').columns.to_list()
     df[number_cols] = df[number_cols][df[number_cols] < math.exp(709)]  # big number
     df[number_cols] = df[number_cols][df[number_cols] != 0.0]

--- a/ta/volume.py
+++ b/ta/volume.py
@@ -289,6 +289,72 @@ class NegativeVolumeIndexIndicator(IndicatorMixin):
         return pd.Series(nvi, name='nvi')
 
 
+class MFIIndicator(IndicatorMixin):
+    """Money Flow Index (MFI)
+
+    Uses both price and volume to measure buying and selling pressure. It is
+    positive when the typical price rises (buying pressure) and negative when
+    the typical price declines (selling pressure). A ratio of positive and
+    negative money flow is then plugged into an RSI formula to create an
+    oscillator that moves between zero and one hundred.
+
+    http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:money_flow_index_mfi
+
+    Args:
+        high(pandas.Series): dataset 'High' column.
+        low(pandas.Series): dataset 'Low' column.
+        close(pandas.Series): dataset 'Close' column.
+        volume(pandas.Series): dataset 'Volume' column.
+        n(int): n period.
+        fillna(bool): if True, fill nan values.
+    """
+
+    def __init__(self,
+                 high: pd.Series,
+                 low: pd.Series,
+                 close: pd.Series,
+                 volume: pd.Series,
+                 n: int = 14,
+                 fillna: bool = False):
+        self._high = high
+        self._low = low
+        self._close = close
+        self._volume = volume
+        self._n = n
+        self._fillna = fillna
+        self._run()
+
+    def _run(self):
+        # 1 typical price
+        tp = (self._high + self._low + self._close) / 3.0
+
+        # 2 up or down column
+        up_down = np.where(tp > tp.shift(1), 1, np.where(tp < tp.shift(1), -1, 0))
+
+        # 3 money flow
+        mf = tp * self._volume * up_down
+
+        # 4 positive and negative money flow with n periods
+        n_positive_mf = mf.rolling(self._n).apply(lambda x: np.sum(np.where(x >= 0.0, x, 0.0)), raw=True)
+        n_negative_mf = abs(mf.rolling(self._n).apply(lambda x: np.sum(np.where(x < 0.0, x, 0.0)), raw=True))
+
+        # n_positive_mf = np.where(mf.rolling(self._n).sum() >= 0.0, mf, 0.0)
+        # n_negative_mf = abs(np.where(mf.rolling(self._n).sum() < 0.0, mf, 0.0))
+
+        # 5 money flow index
+        mr = n_positive_mf / n_negative_mf
+        self._mr = (100 - (100 / (1 + mr)))
+
+    def money_flow_index(self) -> pd.Series:
+        """Money Flow Index (MFI)
+
+        Returns:
+            pandas.Series: New feature generated.
+        """
+        mr = self._check_fillna(self._mr, value=50)
+        return pd.Series(mr, name=f'mfi_{self._n}')
+
+
 def acc_dist_index(high, low, close, volume, fillna=False):
     """Accumulation/Distribution Index (ADI)
 
@@ -476,6 +542,33 @@ def negative_volume_index(close, volume, fillna=False):
         https://en.wikipedia.org/wiki/Negative_volume_index
     """
     return NegativeVolumeIndexIndicator(close=close, volume=volume, fillna=fillna).negative_volume_index()
+
+
+def money_flow_index(high, low, close, volume, n=14, fillna=False):
+    """Money Flow Index (MFI)
+
+    Uses both price and volume to measure buying and selling pressure. It is
+    positive when the typical price rises (buying pressure) and negative when
+    the typical price declines (selling pressure). A ratio of positive and
+    negative money flow is then plugged into an RSI formula to create an
+    oscillator that moves between zero and one hundred.
+
+    http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:money_flow_index_mfi
+
+    Args:
+        high(pandas.Series): dataset 'High' column.
+        low(pandas.Series): dataset 'Low' column.
+        close(pandas.Series): dataset 'Close' column.
+        volume(pandas.Series): dataset 'Volume' column.
+        n(int): n period.
+        fillna(bool): if True, fill nan values.
+
+    Returns:
+        pandas.Series: New feature generated.
+
+    """
+    indicator = MFIIndicator(high=high, low=low, close=close, volume=volume, n=n, fillna=fillna)
+    return indicator.money_flow_index()
 
 
 # TODO

--- a/ta/wrapper.py
+++ b/ta/wrapper.py
@@ -109,9 +109,11 @@ def add_volatility_ta(df: pd.DataFrame, high: str, low: str, close: str,
 
     # Keltner Channel
     indicator_kc = KeltnerChannel(close=df[close], high=df[high], low=df[low], n=10, fillna=fillna)
-    df[f'{colprefix}volatility_kcc'] = indicator_kc.keltner_channel_central()
+    df[f'{colprefix}volatility_kcc'] = indicator_kc.keltner_channel_mband()
     df[f'{colprefix}volatility_kch'] = indicator_kc.keltner_channel_hband()
     df[f'{colprefix}volatility_kcl'] = indicator_kc.keltner_channel_lband()
+    df[f'{colprefix}volatility_kcw'] = indicator_kc.keltner_channel_wband()
+    df[f'{colprefix}volatility_kcp'] = indicator_kc.keltner_channel_pband()
     df[f'{colprefix}volatility_kchi'] = indicator_kc.keltner_channel_hband_indicator()
     df[f'{colprefix}volatility_kcli'] = indicator_kc.keltner_channel_lband_indicator()
 

--- a/ta/wrapper.py
+++ b/ta/wrapper.py
@@ -8,9 +8,8 @@
 import pandas as pd
 
 from ta.momentum import (AwesomeOscillatorIndicator, KAMAIndicator,
-                         MFIIndicator, ROCIndicator, RSIIndicator,
-                         StochasticOscillator, TSIIndicator,
-                         UltimateOscillator, WilliamsRIndicator)
+                         ROCIndicator, RSIIndicator, StochasticOscillator,
+                         TSIIndicator, UltimateOscillator, WilliamsRIndicator)
 from ta.others import (CumulativeReturnIndicator, DailyLogReturnIndicator,
                        DailyReturnIndicator)
 from ta.trend import (MACD, ADXIndicator, AroonIndicator, CCIIndicator,
@@ -21,8 +20,8 @@ from ta.volatility import (AverageTrueRange, BollingerBands, DonchianChannel,
                            KeltnerChannel)
 from ta.volume import (AccDistIndexIndicator, ChaikinMoneyFlowIndicator,
                        EaseOfMovementIndicator, ForceIndexIndicator,
-                       NegativeVolumeIndexIndicator, OnBalanceVolumeIndicator,
-                       VolumePriceTrendIndicator)
+                       MFIIndicator, NegativeVolumeIndexIndicator,
+                       OnBalanceVolumeIndicator, VolumePriceTrendIndicator)
 
 
 def add_volume_ta(df: pd.DataFrame, high: str, low: str, close: str, volume: str,
@@ -57,6 +56,10 @@ def add_volume_ta(df: pd.DataFrame, high: str, low: str, close: str, volume: str
     # Force Index
     df[f'{colprefix}volume_fi'] = ForceIndexIndicator(
         close=df[close], volume=df[volume], n=13, fillna=fillna).force_index()
+
+    # Money Flow Indicator
+    df[f'{colprefix}momentum_mfi'] = MFIIndicator(
+        high=df[high], low=df[low], close=df[close], volume=df[volume], n=14, fillna=fillna).money_flow_index()
 
     # Ease of Movement
     indicator = EaseOfMovementIndicator(high=df[high], low=df[low], volume=df[volume], n=14, fillna=fillna)
@@ -230,10 +233,6 @@ def add_momentum_ta(df: pd.DataFrame, high: str, low: str, close: str, volume: s
 
     # Relative Strength Index (RSI)
     df[f'{colprefix}momentum_rsi'] = RSIIndicator(close=df[close], n=14, fillna=fillna).rsi()
-
-    # Money Flow Indicator
-    df[f'{colprefix}momentum_mfi'] = MFIIndicator(
-        high=df[high], low=df[low], close=df[close], volume=df[volume], n=14, fillna=fillna).money_flow_index()
 
     # TSI Indicator
     df[f'{colprefix}momentum_tsi'] = TSIIndicator(close=df[close], r=25, s=13, fillna=fillna).tsi()


### PR DESCRIPTION
* Keltner Channel:

  * Fixing bug on Keltner channel high band calculation. Based on: https://github.com/bukosabino/ta/issues/126
  * Included percentage band and width band indicators for Keltner Channel. 
  * Included 2 ways to calculate the centerline of Keltner Channel: original version (SMA of typical price) vs modern version (EMA of close)

* Volume indicators isolation: Isolate all the indicators using the volume input feature to get all together using add_volume_ta wrapper function. Based on: https://github.com/bukosabino/ta/issues/129