### PR TITLE
Bug fix for wrapper reference to Ulcer Index feature

### DIFF
--- a/ta/tests/wrapper.py
+++ b/ta/tests/wrapper.py
@@ -28,3 +28,11 @@ class TestWrapper(unittest.TestCase):
         # Add all ta features not filling nans values
         ta.add_all_ta_features(
             df=df, open="Open", high="High", low="Low", close="Close", volume="Volume_BTC", fillna=False)
+
+        # Check added ta features are all numerical values after filling nans
+        input_cols = self._df.columns
+        df_with_ta = ta.add_all_ta_features(
+            df=df, open="Open", high="High", low="Low", close="Close", volume="Volume_BTC", fillna=True
+        )
+        ta_cols = [c for c in df_with_ta.columns if c not in input_cols]
+        assert df_with_ta[ta_cols].apply(lambda series: pd.to_numeric(series, errors='coerce')).notnull().all().all()

--- a/ta/wrapper.py
+++ b/ta/wrapper.py
@@ -134,7 +134,7 @@ def add_volatility_ta(df: pd.DataFrame, high: str, low: str, close: str,
     df[f'{colprefix}volatility_dcp'] = indicator_dc.donchian_channel_pband()
 
     # Ulcer Index
-    df[f'{colprefix}volatility_ui'] = UlcerIndex(close=df[close], n=14, fillna=fillna)
+    df[f'{colprefix}volatility_ui'] = UlcerIndex(close=df[close], n=14, fillna=fillna).ulcer_index()
 
     return df
 


### PR DESCRIPTION
Ensure that Ulcer Index feature values are returned in numerical representation within the Dataframe instead of as UlcerIndex objects. Currently when calling `add_volatility_ta(df...`, the DataFrame returned has a non numerical UlcerIndex column, where UlcerIndex objects exist within each row, instead of the correct float representation of the feature.


Before:
<img width="566" alt="image" src="https://user-images.githubusercontent.com/6901786/99322349-a894d200-2867-11eb-9e34-4e9440966913.png">

After:
<img width="569" alt="image" src="https://user-images.githubusercontent.com/6901786/99322386-be09fc00-2867-11eb-858a-e126ee9ed51b.png">


Please review. 

Many thanks!