### PR TITLE
Handle division by zero in Bollinger Band pband

### DIFF
--- a/ta/volatility.py
+++ b/ta/volatility.py
@@ -145,7 +145,7 @@ class BollingerBands(IndicatorMixin):
         Returns:
             pandas.Series: New feature generated.
         """
-        pband = (self._close - self._lband) / (self._hband - self._lband)
+        pband = (self._close - self._lband) / (self._hband - self._lband).where(self._hband != self._lband, np.nan)
         pband = self._check_fillna(pband, value=0)
         return pd.Series(pband, name="bbipband")
 


### PR DESCRIPTION
There are times when for the whole period of Bollinger Band no price changes happen. Thus, top/bottom/mid and close are all the same. In this case pband calculation cause div by zero. This change would set it to NaN in these cases. Indeed, there is no good default - the price "touches" all three lines at the same time.

PS: didn't see contribution guidelines to just sending this PR. If there is a better way - let me know and I do.