### PR TITLE
Adjusted starting indices for adx_pos and adx_neg

### DIFF
--- a/ta/trend.py
+++ b/ta/trend.py
@@ -796,7 +796,7 @@ class ADXIndicator(IndicatorMixin):
             pandas.Series: New feature generated.
         """
         dip = np.zeros(len(self._close))
-        for i in range(1, len(self._trs) - 1):
+        for i in range(0, len(self._trs) - 1):
             dip[i + self._window] = 100 * (self._dip[i] / self._trs[i])
 
         adx_pos_series = self._check_fillna(
@@ -811,7 +811,7 @@ class ADXIndicator(IndicatorMixin):
             pandas.Series: New feature generated.
         """
         din = np.zeros(len(self._close))
-        for i in range(1, len(self._trs) - 1):
+        for i in range(0, len(self._trs) - 1):
             din[i + self._window] = 100 * (self._din[i] / self._trs[i])
 
         adx_neg_series = self._check_fillna(


### PR DESCRIPTION
Changed the starting index in rows 799 and 814 from 1 to 0.
Otherwise, when printing the final adx together with adx_neg and adx_pos, it looked like the adx was computed based on one row too little.
Computation was correct, just looked wrong.