### PR TITLE
fixing NaNs issue on KAMA

### DIFF
--- a/ta/momentum.py
+++ b/ta/momentum.py
@@ -321,7 +321,9 @@ class KAMAIndicator(IndicatorMixin):
         min_periods = 0 if self._fillna else self._window
         er_num = abs(close_values - np.roll(close_values, self._window))
         er_den = vol.rolling(self._window, min_periods=min_periods).sum()
-        efficiency_ratio = er_num / er_den
+        efficiency_ratio = np.divide(
+            er_num, er_den, out=np.zeros_like(er_num), where=er_den != 0
+        )
 
         smoothing_constant = (
             (


### PR DESCRIPTION
This PR is to fix a bug causing KAMA to be NaN if no a given stock close price did not change for more than the KAMA window size.

The bug is caused because efficiency ratio is NaN in such cases, instead of 0.
The solution is to use np.divide to calculate ER as `er_num / er_den` except for cases `er_num == 0`, then 0