### PR TITLE
The behavior of `series[i:j]` with an integer-dtype index is deprecated.

### DIFF
--- a/ta/trend.py
+++ b/ta/trend.py
@@ -727,7 +727,7 @@ class ADXIndicator(IndicatorMixin):
 
         self._trs_initial = np.zeros(self._window - 1)
         self._trs = np.zeros(len(self._close) - (self._window - 1))
-        self._trs[0] = diff_directional_movement.dropna()[
+        self._trs[0] = diff_directional_movement.dropna().iloc[
             0: self._window].sum()
         diff_directional_movement = diff_directional_movement.reset_index(
             drop=True)


### PR DESCRIPTION
FutureWarning: The behavior of `series[i:j]` with an integer-dtype index is deprecated. In a future version, this will be treated as *label-based* indexing, consistent with e.g. `series[i]` lookups. To retain the old behavior, use `series.iloc[i:j]`. To get the future behavior, use `series.loc[i:j]`.