### PR TITLE
Added 0-in-denominator checks in trend.ADXIndicator

### DIFF
--- a/ta/trend.py
+++ b/ta/trend.py
@@ -721,26 +721,24 @@ class ADXIndicator(IndicatorMixin):
             raise ValueError("window may not be 0")
 
         close_shift = self._close.shift(1)
+        
         pdm = _get_min_max(self._high, close_shift, "max")
         pdn = _get_min_max(self._low, close_shift, "min")
+        
         diff_directional_movement = pdm - pdn
 
         self._trs_initial = np.zeros(self._window - 1)
         self._trs = np.zeros(len(self._close) - (self._window - 1))
-        self._trs[0] = diff_directional_movement.dropna()[
-            0: self._window].sum()
-        diff_directional_movement = diff_directional_movement.reset_index(
-            drop=True)
+        self._trs[0] = diff_directional_movement.dropna()[0: self._window].sum()
+        
+        diff_directional_movement = diff_directional_movement.reset_index(drop=True)
 
         for i in range(1, len(self._trs) - 1):
-            self._trs[i] = (
-                self._trs[i - 1]
-                - (self._trs[i - 1] / float(self._window))
-                + diff_directional_movement[self._window + i]
-            )
+            self._trs[i] = (self._trs[i - 1] - (self._trs[i - 1] / float(self._window)) + diff_directional_movement[self._window + i])
 
         diff_up = self._high - self._high.shift(1)
         diff_down = self._low.shift(1) - self._low
+
         pos = abs(((diff_up > diff_down) & (diff_up > 0)) * diff_up)
         neg = abs(((diff_down > diff_up) & (diff_down > 0)) * diff_down)
 
@@ -750,11 +748,7 @@ class ADXIndicator(IndicatorMixin):
         pos = pos.reset_index(drop=True)
 
         for i in range(1, len(self._dip) - 1):
-            self._dip[i] = (
-                self._dip[i - 1]
-                - (self._dip[i - 1] / float(self._window))
-                + pos[self._window + i]
-            )
+            self._dip[i] = (self._dip[i - 1] - (self._dip[i - 1] / float(self._window)) + pos[self._window + i])
 
         self._din = np.zeros(len(self._close) - (self._window - 1))
         self._din[0] = neg.dropna()[0: self._window].sum()
@@ -762,11 +756,7 @@ class ADXIndicator(IndicatorMixin):
         neg = neg.reset_index(drop=True)
 
         for i in range(1, len(self._din) - 1):
-            self._din[i] = (
-                self._din[i - 1]
-                - (self._din[i - 1] / float(self._window))
-                + neg[self._window + i]
-            )
+            self._din[i] = (self._din[i - 1] - (self._din[i - 1] / float(self._window)) + neg[self._window + i])
 
     def adx(self) -> pd.Series:
         """Average Directional Index (ADX)
@@ -777,29 +767,42 @@ class ADXIndicator(IndicatorMixin):
         dip = np.zeros(len(self._trs))
 
         for idx, value in enumerate(self._trs):
-            dip[idx] = 100 * (self._dip[idx] / value)
+            if value != 0:
+                dip[idx] = 100 * (self._dip[idx] / value)
+
+            else:
+                dip[idx] = 0
 
         din = np.zeros(len(self._trs))
 
         for idx, value in enumerate(self._trs):
-            din[idx] = 100 * (self._din[idx] / value)
+            if value != 0:
+                din[idx] = 100 * (self._din[idx] / value)
 
-        directional_index = 100 * np.abs((dip - din) / (dip + din))
+            else:
+                din[idx] = 0
+
+        directional_index = np.zeros(len(self._trs))
+
+        for idx in range(len(self._trs)):
+            if dip[idx] + din[idx] != 0:
+                directional_index[idx] = 100 * np.abs((dip[idx] - din[idx]) / (dip[idx] + din[idx]))
+
+            else:
+                directional_index[idx] = 0
 
         adx_series = np.zeros(len(self._trs))
         adx_series[self._window] = directional_index[0: self._window].mean()
 
         for i in range(self._window + 1, len(adx_series)):
-            adx_series[i] = (
-                (adx_series[i - 1] * (self._window - 1)) +
-                directional_index[i - 1]
-            ) / float(self._window)
+            adx_series[i] = ((adx_series[i - 1] * (self._window - 1)) + directional_index[i - 1]) / float(self._window)
 
         adx_series = np.concatenate((self._trs_initial, adx_series), axis=0)
         adx_series = pd.Series(data=adx_series, index=self._close.index)
-
         adx_series = self._check_fillna(adx_series, value=20)
+
         return pd.Series(adx_series, name="adx")
+
 
     def adx_pos(self) -> pd.Series:
         """Plus Directional Indicator (+DI)
@@ -808,13 +811,18 @@ class ADXIndicator(IndicatorMixin):
             pandas.Series: New feature generated.
         """
         dip = np.zeros(len(self._close))
-        for i in range(1, len(self._trs) - 1):
-            dip[i + self._window] = 100 * (self._dip[i] / self._trs[i])
 
-        adx_pos_series = self._check_fillna(
-            pd.Series(dip, index=self._close.index), value=20
-        )
+        for i in range(1, len(self._trs) - 1):
+            if self._trs[i] != 0:
+                dip[i + self._window] = 100 * (self._dip[i] / self._trs[i])
+
+            else:
+                dip[i + self._window] = 0
+
+        adx_pos_series = self._check_fillna(pd.Series(dip, index=self._close.index), value=20)
+        
         return pd.Series(adx_pos_series, name="adx_pos")
+
 
     def adx_neg(self) -> pd.Series:
         """Minus Directional Indicator (-DI)
@@ -823,13 +831,18 @@ class ADXIndicator(IndicatorMixin):
             pandas.Series: New feature generated.
         """
         din = np.zeros(len(self._close))
-        for i in range(1, len(self._trs) - 1):
-            din[i + self._window] = 100 * (self._din[i] / self._trs[i])
 
-        adx_neg_series = self._check_fillna(
-            pd.Series(din, index=self._close.index), value=20
-        )
+        for i in range(1, len(self._trs) - 1):
+            if self._trs[i] != 0:
+                din[i + self._window] = 100 * (self._din[i] / self._trs[i])
+
+            else:
+                din[i + self._window] = 0
+
+        adx_neg_series = self._check_fillna(pd.Series(din, index=self._close.index), value=20)
+        
         return pd.Series(adx_neg_series, name="adx_neg")
+
 
 
 class VortexIndicator(IndicatorMixin):


### PR DESCRIPTION
I was getting this "invalid value encountered in scalar divide" warning with any input data I used. I searched for a fix but no amount of data-transformations worked, then I saw many users reporting the same issue in the exact same line `dip[idx] = 100 * (self._dip[idx] / value)`, so I wrote a simple fix for it. In short, I added checks to make sure we never divide by 0. 