### PR TITLE
replaced fill_value to 1 instead of close.mean

### DIFF
--- a/ta/others.py
+++ b/ta/others.py
@@ -25,9 +25,7 @@ class DailyReturnIndicator(IndicatorMixin):
         self._run()
 
     def _run(self):
-        self._dr = (
-            self._close / self._close.shift(1, fill_value=1)
-        ) - 1
+        self._dr = (self._close / self._close.shift(1)) - 1
         self._dr *= 100
 
     def daily_return(self) -> pd.Series:

--- a/ta/others.py
+++ b/ta/others.py
@@ -26,7 +26,7 @@ class DailyReturnIndicator(IndicatorMixin):
 
     def _run(self):
         self._dr = (
-            self._close / self._close.shift(1, fill_value=self._close.mean())
+            self._close / self._close.shift(1, fill_value=1)
         ) - 1
         self._dr *= 100
 


### PR DESCRIPTION
As found in https://github.com/bukosabino/ta/issues/323, DailyReturnIndicator will cause future data leakage when filling nan values (possibly only on the first row, as it's used with shift(1)).

This PR removed the `fillna` argument from the `shift` operation.  This is because if there is no value for the stock in the previous row, the actual value should be NaN. Later, when calling the `daily_return` method, the user can chose if to fill the NaN or not.

In any case, filling with `close.mean()` is wrong.