### PR TITLE
Handle initial OBV value & Handle 0's

### DIFF
--- a/ta/volume.py
+++ b/ta/volume.py
@@ -83,7 +83,15 @@ class OnBalanceVolumeIndicator(IndicatorMixin):
         self._run()
 
     def _run(self):
-        obv = np.where(self._close < self._close.shift(1), -self._volume, self._volume)
+        close_prev = self._close.shift(1)
+        obv = np.zeros_like(self._volume) 
+
+        close_up_mask = self._close > close_prev
+        close_dn_mask = self._close < close_prev
+
+        obv[close_up_mask] = self._volume[close_up_mask]
+        obv[close_dn_mask] = -self._volume[close_dn_mask]
+
         self._obv = pd.Series(obv, index=self._close.index).cumsum()
 
     def on_balance_volume(self) -> pd.Series:
@@ -625,7 +633,11 @@ def sma_ease_of_movement(high, low, volume, window=14, fillna=False):
 
 
 def volume_price_trend(
-    close, volume, fillna=False, smoothing_factor: tp.Optional[int] = None, dropnans: bool = False
+    close,
+    volume,
+    fillna=False,
+    smoothing_factor: tp.Optional[int] = None,
+    dropnans: bool = False,
 ):
     """Volume-price trend (VPT)
 


### PR DESCRIPTION
While writing my own ta library, I noticed a discrepancy between my OBV values and ta's.

I did some digging and noticed 2 easy to fix issues. I've ran the unit tests and everything still works 👍 

**Issues**:
1. For the initial volume value, we apply 0 because there is no history to confirm whether the movement was up or down.
2. When the current days close is equal to the previous, we apply 0 because there was no up or down movement.

**Fixes**:
1. Initialize an empty zeros array with the same shape as the volume with np.zeros_like()
2. Use masks the insert positive and negative volume values into the zeros array.

**Reasoning**:
1. We can see in the screenshot below, that the initial day has *no* obv value. This is effectively 0
![Screenshot 2024-09-13 011141](https://github.com/user-attachments/assets/5d09234e-30d8-4db8-8fbe-4828402c1d98)
2. In the Investopedia formula, we can see *if close = close_prev then 0*, this is not handled properly in the current implementation. 
![Screenshot 2024-09-13 003324](https://github.com/user-attachments/assets/1d2e8aba-5367-4dfc-b386-f301fddd9ba0)

**Tests**:
![Screenshot 2024-09-13 011442](https://github.com/user-attachments/assets/f52eec0a-d634-4e5a-90c9-26bd3f6500b2)

 