### PR TITLE
fix: use iloc for consistent positional indexing in PSARIndicator

### DIFF
--- a/ta/trend.py
+++ b/ta/trend.py
@@ -1027,7 +1027,7 @@ class PSARIndicator(IndicatorMixin):
                     high1 = self._high.iloc[i - 1]
                     high2 = self._high.iloc[i - 2]
                     if high2 > self._psar.iloc[i]:
-                        self._psar[i] = high2
+                        self._psar.iloc[i] = high2
                     elif high1 > self._psar.iloc[i]:
                         self._psar.iloc[i] = high1
 


### PR DESCRIPTION
## Summary

Fix inconsistent Series indexing in `PSARIndicator._run()` where `self._psar[i]` was used instead of `self._psar.iloc[i]` at line 1030 of `ta/trend.py`.

## Problem

In pandas, `Series.__setitem__` with integer keys treats them as **labels**, not positions. This causes:
- A `FutureWarning` in recent pandas versions
- Potential incorrect behavior when the Series index doesn't match integer positions

All other indexing operations in the same method already correctly use `.iloc[i]`, making this the only inconsistency.

## Fix

```diff
-                        self._psar[i] = high2
+                        self._psar.iloc[i] = high2
```

## Issues Resolved

Fixes #354
Fixes #357  
Fixes #348