### PR TITLE
Add Rank and Percentile indicators

### DIFF
--- a/ta/others.py
+++ b/ta/others.py
@@ -94,6 +94,93 @@ class CumulativeReturnIndicator(IndicatorMixin):
         return pd.Series(cum_ret, name="cum_ret")
 
 
+class RankIndicator(IndicatorMixin):
+    """Rank (IVR-style)
+
+    Computes the rolling rank of the current value within a lookback window,
+    expressed as a percentage (0-100). Commonly used for Implied Volatility
+    Rank (IVR).
+
+    Rank = (current - min) / (max - min) * 100
+
+    Reference:
+        https://www.tastylive.com/concepts-strategies/implied-volatility-rank-percentile
+
+    Args:
+        close(pandas.Series): dataset column to rank.
+        window(int): lookback period.
+        fillna(bool): if True, fill nan values.
+    """
+
+    def __init__(self, close: pd.Series, window: int = 252, fillna: bool = False):
+        self._close = close
+        self._window = window
+        self._fillna = fillna
+        self._run()
+
+    def _run(self):
+        rolling_min = self._close.rolling(window=self._window, min_periods=1).min()
+        rolling_max = self._close.rolling(window=self._window, min_periods=1).max()
+        denom = rolling_max - rolling_min
+        self._rank = np.where(denom != 0, (self._close - rolling_min) / denom * 100, 0)
+        self._rank = pd.Series(self._rank, index=self._close.index)
+
+    def rank(self) -> pd.Series:
+        """Rank (IVR-style)
+
+        Returns:
+            pandas.Series: New feature generated (0-100).
+        """
+        rank_series = self._check_fillna(self._rank, value=0)
+        return pd.Series(rank_series, name="rank")
+
+
+class PercentileIndicator(IndicatorMixin):
+    """Percentile (IVP-style)
+
+    Computes the rolling percentile of the current value within a lookback
+    window, expressed as a percentage (0-100). Commonly used for Implied
+    Volatility Percentile (IVP).
+
+    Percentile = (number of values below current) / total values * 100
+
+    Reference:
+        https://www.tastylive.com/concepts-strategies/implied-volatility-rank-percentile
+
+    Args:
+        close(pandas.Series): dataset column to compute percentile for.
+        window(int): lookback period.
+        fillna(bool): if True, fill nan values.
+    """
+
+    def __init__(self, close: pd.Series, window: int = 252, fillna: bool = False):
+        self._close = close
+        self._window = window
+        self._fillna = fillna
+        self._run()
+
+    def _run(self):
+        def _pct(arr):
+            if len(arr) < 2:
+                return 0.0
+            current = arr.iloc[-1]
+            below = (arr.iloc[:-1] < current).sum()
+            return below / (len(arr) - 1) * 100
+
+        self._percentile = self._close.rolling(
+            window=self._window, min_periods=2
+        ).apply(_pct, raw=False)
+
+    def percentile(self) -> pd.Series:
+        """Percentile (IVP-style)
+
+        Returns:
+            pandas.Series: New feature generated (0-100).
+        """
+        pct_series = self._check_fillna(self._percentile, value=0)
+        return pd.Series(pct_series, name="percentile")
+
+
 def daily_return(close, fillna=False):
     """Daily Return (DR)
 


### PR DESCRIPTION
Fixes #359.

Adds two new indicators to `ta.others`:

**RankIndicator** (IVR-style)
- `(current - min) / (max - min) * 100` over a rolling window
- Used for Implied Volatility Rank

**PercentileIndicator** (IVP-style)
- Fraction of historical values below current value * 100
- Used for Implied Volatility Percentile

Both use 252-day default lookback (1 year of trading days), configurable via `window` parameter. Follows existing class pattern with `fillna` support.

Reference: https://www.tastylive.com/concepts-strategies/implied-volatility-rank-percentile