### PR TITLE
Fix Aroon Up/Down: count periods since the most recent high/low

### DIFF
--- a/ta/trend.py
+++ b/ta/trend.py
@@ -44,12 +44,14 @@ class AroonIndicator(IndicatorMixin):
 
         rolling_high = self._high.rolling(self._window + 1, min_periods=min_periods)
         self._aroon_up = rolling_high.apply(
-            lambda x: float(np.argmax(x)) / self._window * 100, raw=True
+            lambda x: float(len(x) - 1 - np.argmax(x[::-1])) / self._window * 100,
+            raw=True,
         )
 
         rolling_low = self._low.rolling(self._window + 1, min_periods=min_periods)
         self._aroon_down = rolling_low.apply(
-            lambda x: float(np.argmin(x)) / self._window * 100, raw=True
+            lambda x: float(len(x) - 1 - np.argmin(x[::-1])) / self._window * 100,
+            raw=True,
         )
 
     def aroon_up(self) -> pd.Series:

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -13,6 +13,7 @@ from test.unit.momentum import (
 )
 from test.unit.trend import (
     TestADXIndicator,
+    TestAroonIndicator,
     TestCCIIndicator,
     TestMACDIndicator,
     TestPSARIndicator,
@@ -52,6 +53,7 @@ __all__ = [
     "TestUltimateOscillator",
     "TestWilliamsRIndicator",
     "TestADXIndicator",
+    "TestAroonIndicator",
     "TestCCIIndicator",
     "TestMACDIndicator",
     "TestPSARIndicator",

--- a/test/unit/trend.py
+++ b/test/unit/trend.py
@@ -5,6 +5,7 @@ import pandas as pd
 from ta.trend import (
     MACD,
     ADXIndicator,
+    AroonIndicator,
     CCIIndicator,
     PSARIndicator,
     STCIndicator,
@@ -13,6 +14,8 @@ from ta.trend import (
     adx,
     adx_neg,
     adx_pos,
+    aroon_down,
+    aroon_up,
     cci,
     macd,
     macd_diff,
@@ -398,6 +401,58 @@ class TestWMAIndicator(unittest.TestCase):
         result = wma_indicator(**self._params)
         pd.testing.assert_series_equal(
             self._df[target].tail(), result.tail(), check_names=False
+        )
+
+
+class TestAroonIndicator(unittest.TestCase):
+    """Aroon Up/Down.
+
+    Aroon Up  = ((N - periods since the N-period high) / N) * 100
+    Aroon Down = ((N - periods since the N-period low) / N) * 100
+
+    "Periods since the high/low" must be counted from the most recent
+    occurrence of the extreme. In particular, when the current bar sets (or
+    ties) the N-period high, Aroon Up must be 100 (0 periods since the high).
+
+    https://www.investopedia.com/terms/a/aroon.asp
+    """
+
+    def setUp(self):
+        self._window = 4
+        # last window+1 (=5) highs: [8, 10, 9, 7, 10] -> current bar ties the
+        # period high (10) -> 0 periods since high -> Aroon Up = 100.
+        self._high = pd.Series([5.0, 8.0, 10.0, 9.0, 7.0, 10.0])
+        # last window+1 lows: [6, 4, 5, 7, 4] -> current bar ties the period
+        # low (4) -> 0 periods since low -> Aroon Down = 100.
+        self._low = pd.Series([9.0, 6.0, 4.0, 5.0, 7.0, 4.0])
+        self._params = {
+            "high": self._high,
+            "low": self._low,
+            "window": self._window,
+            "fillna": False,
+        }
+        self._indicator = AroonIndicator(**self._params)
+
+    def test_aroon_up_current_bar_ties_high(self):
+        result = self._indicator.aroon_up()
+        # current bar ties the period high -> 100
+        self.assertAlmostEqual(result.iloc[-1], 100.0)
+        # previous bar: unique high 3 bars back within its window -> 50
+        self.assertAlmostEqual(result.iloc[-2], 50.0)
+
+    def test_aroon_down_current_bar_ties_low(self):
+        result = self._indicator.aroon_down()
+        self.assertAlmostEqual(result.iloc[-1], 100.0)
+        self.assertAlmostEqual(result.iloc[-2], 50.0)
+
+    def test_aroon_functional_matches_class(self):
+        pd.testing.assert_series_equal(
+            aroon_up(**self._params), self._indicator.aroon_up(), check_names=False
+        )
+        pd.testing.assert_series_equal(
+            aroon_down(**self._params),
+            self._indicator.aroon_down(),
+            check_names=False,
         )
 
 


### PR DESCRIPTION
## Problem

`AroonIndicator` computes "periods since the N-period high/low" with `np.argmax` / `np.argmin`. These return the **first (oldest)** occurrence of the extreme in the rolling window. Aroon's definition requires counting from the **most recent** occurrence:

- Aroon Up = ((N − periods since the N-period high) / N) × 100
- Aroon Down = ((N − periods since the N-period low) / N) × 100

When the highest high (or lowest low) is not unique within the window, the current code counts from the wrong bar and reports a value that is too low.

The most visible symptom is at the moment Aroon is meant to flag: when the **current bar sets or ties the N-period high**, Aroon Up should be **100** (0 periods since the high), but the indicator returns a smaller number because an earlier equal high is used instead.

### Reproduction

```python
import pandas as pd
from ta.trend import AroonIndicator

# window = 4; last 5 highs = [8, 10, 9, 7, 10] -> current bar ties the period high
high = pd.Series([5.0, 8.0, 10.0, 9.0, 7.0, 10.0])
low  = pd.Series([9.0, 6.0, 4.0, 5.0, 7.0, 4.0])

ai = AroonIndicator(high=high, low=low, window=4)
print(ai.aroon_up().iloc[-1])    # -> 25.0  (expected 100.0)
print(ai.aroon_down().iloc[-1])  # -> 25.0  (expected 100.0)
```

## Fix

Use the **last** occurrence of the extreme within each window so ties resolve to the most recent bar (matching the textbook definition and the behaviour of other TA implementations). Results are unchanged whenever the extreme is unique, so this only affects the tie cases that were previously wrong.

## Tests

Added `TestAroonIndicator` (registered in `test/__init__.py`) covering the tie-at-current-bar case for both Aroon Up and Aroon Down, plus a unique-extreme sanity check and functional/class parity. Fails before the change, passes after. Existing tests are unaffected.