### PR TITLE
Fix PSAR series assignment to use .iloc consistently

### DIFF
--- a/ta/trend.py
+++ b/ta/trend.py
@@ -1027,7 +1027,7 @@ class PSARIndicator(IndicatorMixin):
                     high1 = self._high.iloc[i - 1]
                     high2 = self._high.iloc[i - 2]
                     if high2 > self._psar.iloc[i]:
-                        self._psar[i] = high2
+                        self._psar.iloc[i] = high2
                     elif high1 > self._psar.iloc[i]:
                         self._psar.iloc[i] = high1
 


### PR DESCRIPTION
## Summary
Fixes #354, #357, #339, #348 — all four report the same root cause independently.

In `PSARIndicator._run` (ta/trend.py), one line uses bare positional indexing:

```python
if high2 > self._psar.iloc[i]:
    self._psar[i] = high2          # inconsistent / deprecated
elif high1 > self._psar.iloc[i]:
    self._psar.iloc[i] = high1     # already correct
```

Every other read/write of `self._psar` in this method already goes through `.iloc[i]`. The one exception triggers pandas' `FutureWarning: Series.__setitem__ treating keys as positions is deprecated` (reported in #357, #339, #348) and was also flagged directly as an indexing inconsistency in #354, which includes the exact proposed fix.

## Change
```python
self._psar[i] = high2
```
→
```python
self._psar.iloc[i] = high2
```

One line, no behavior change — `.iloc[i]` and positional `[i]` currently resolve to the same element for this integer-indexed Series; the fix only removes the deprecated code path and makes the method internally consistent.

## Test plan
- [x] Confirmed via source inspection that this is the only remaining bare-positional assignment on `self._psar` in the method — all other accesses already use `.iloc`.
- [x] Change matches the fix proposed in #354 exactly.
- [ ] Not run through the project's test suite locally — flagging for maintainer/CI verification.
